### PR TITLE
Make Poison an all-envs dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Shopify.Mixfile do
     [
       {:bypass, git: "https://github.com/pspdfkit-labs/bypass.git", only: :test},
       {:oauth2, "~> 0.8.0"},
-      {:poison, "~> 3.0.0", only: :test},
+      {:poison, "~> 3.0.0"},
     ]
   end
 end


### PR DESCRIPTION
When adding this dependency, I forgot that it's needed for oauth2 so I
marked it as only applicable to the test environment. This should allow
Webhook requests to be created without error.