### PR TITLE
Specify an OAuth token directly

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,5 @@
 use Mix.Config
 
 config :shopify,
+  api_key: "abcd1234",
   secret: "634f64859844d16069c35f0c11a287d6509de06dfe90a30ea69d56996900bff3"

--- a/lib/shopify/oauth.ex
+++ b/lib/shopify/oauth.ex
@@ -7,15 +7,23 @@ defmodule Shopify.Oauth do
     secrets = Application.get_all_env(:shopify)
     oauth_base = secrets[:oauth_site] || "https://#{shopid}.myshopify.com/admin"
 
-    OAuth2.Client.new([
+    client = OAuth2.Client.new([
       strategy: __MODULE__,
       client_id: secrets[:api_key],
       client_secret: secrets[:secret],
       redirect_uri: options[:redirect_uri],
       site: oauth_base,
       authorize_url: "#{oauth_base}/oauth/authorize",
-      token_url: "#{oauth_base}/oauth/access_token"
+      token_url: "#{oauth_base}/oauth/access_token",
     ])
+
+    if options[:token] do
+      client
+      |> Map.put(:token, %OAuth2.AccessToken{token_type: "Bearer", access_token: options[:token]})
+    else
+      client
+    end
+
   end
 
   def authorize_url!(shopid, params \\ []) do

--- a/test/shopify/oauth_test.exs
+++ b/test/shopify/oauth_test.exs
@@ -15,6 +15,14 @@ defmodule Shopify.OauthTest do
     assert strategy == Shopify.Oauth
   end
 
+  test "create/2 sets the token directly from secrets" do
+    shopid = "spatula-city"
+    token = "abcd1234567890"
+    %OAuth2.Client{token: access_token} = Oauth.create(shopid, token: token)
+
+    assert access_token == %OAuth2.AccessToken{token_type: "Bearer", access_token: token}
+  end
+
   test "authorize_url!/2 returns a URL", %{bypass: bypass} do
     shopid = "spatula-city"
     scopes = "read_widgets"
@@ -22,7 +30,7 @@ defmodule Shopify.OauthTest do
     options = %{shopid: shopid, scope: scopes, redirect_uri: redirect_uri}
     auth_url = Shopify.Oauth.authorize_url!(shopid, options)
     expected_params = %{
-      client_id: nil,
+      client_id: "abcd1234",
       redirect_uri: redirect_uri,
       response_type: "code",
       scope: scopes,


### PR DESCRIPTION
In addition to the full OAuth2 cycle, Shopify allows apps to connect as
"private apps" using a generated client_id / secret pair. In order to
support this connection method, we need to pass that secret in rather
than expecting the OAuth client to ask for it.